### PR TITLE
Fixing multipolygon outline bug

### DIFF
--- a/python/src/hydrobricks/behaviours/behaviour_land_cover_change.py
+++ b/python/src/hydrobricks/behaviours/behaviour_land_cover_change.py
@@ -12,6 +12,7 @@ from .behaviour import Behaviour
 if hb.has_shapely:
     from shapely.geometry import mapping
     from shapely.ops import unary_union
+    from shapely.geometry import MultiPolygon
 
 if hb.has_rasterio:
     from rasterio.mask import mask
@@ -278,7 +279,7 @@ class BehaviourLandCoverChange(Behaviour):
         # Clip the glaciers to the catchment extent
         all_glaciers = hb.gpd.read_file(glaciers_shapefile)
         all_glaciers.to_crs(catchment.crs, inplace=True)
-        glaciers = hb.gpd.clip(all_glaciers, catchment.outline)
+        glaciers = hb.gpd.clip(all_glaciers, MultiPolygon(catchment.outline))
         glaciers = self._simplify_df_geometries(glaciers)
 
         # Compute the glaciated area of the catchment

--- a/python/src/hydrobricks/catchment.py
+++ b/python/src/hydrobricks/catchment.py
@@ -99,7 +99,7 @@ class Catchment:
             raise FileNotFoundError(f"File {dem_path} does not exist.")
 
         try:
-            geoms = [mapping(self.outline)]
+            geoms = [mapping(polygon) for polygon in self.outline]
             src = hb.rasterio.open(dem_path)
             self._check_crs(src)
             self.dem = src
@@ -556,7 +556,7 @@ class Catchment:
         shapefile = hb.gpd.read_file(outline)
         self._check_crs(shapefile)
         geoms = shapefile.geometry.values
-        self.outline = geoms[0]
+        self.outline = geoms
 
     def _extract_unit_mean_aspect(self, mask_unit):
         aspect_rad = np.radians(self.aspect[mask_unit])


### PR DESCRIPTION
Fixing a bug that occurs when the study area outline comprises multiple polygons, which happens with diagonal flow paths.