### PR TITLE
Adding a warmup option to eval()

### DIFF
--- a/python/src/hydrobricks/models/model.py
+++ b/python/src/hydrobricks/models/model.py
@@ -286,7 +286,7 @@ class Model(ABC):
         """
         self.model.dump_outputs(path)
 
-    def eval(self, metric, observations):
+    def eval(self, metric, observations, warmup=0):
         """
         Evaluate the simulation using the provided metric (goodness of fit).
 
@@ -299,12 +299,20 @@ class Model(ABC):
         observations : np.array
             The time series of the observations with dates matching the simulated
             series.
+        warmup
+            The number of days of warmup period. This option is used to 
+            discard the warmup period from the evaluation. It is useful when 
+            conducting a run with a specific parameter set and comparing 
+            its score with an inversion run. By setting the 'warmup' value, 
+            you can ensure fair and accurate assessments by discarding data 
+            from the specified warmup period (as is done automatically in an
+            inversion run).
 
         Returns
         -------
         The value of the selected metric.
         """
-        return hb.evaluate(self.get_outlet_discharge(), observations, metric)
+        return hb.evaluate(self.get_outlet_discharge()[warmup:], observations[warmup:], metric)
 
     def generate_parameters(self):
         ps = hb.ParameterSet()

--- a/python/src/hydrobricks/models/model.py
+++ b/python/src/hydrobricks/models/model.py
@@ -299,14 +299,14 @@ class Model(ABC):
         observations : np.array
             The time series of the observations with dates matching the simulated
             series.
-        warmup
+        warmup : int
             The number of days of warmup period. This option is used to 
             discard the warmup period from the evaluation. It is useful when 
             conducting a run with a specific parameter set and comparing 
-            its score with an inversion run. By setting the 'warmup' value, 
-            you can ensure fair and accurate assessments by discarding data 
-            from the specified warmup period (as is done automatically in an
-            inversion run).
+            its score with those from the calibration. By setting the 'warmup' 
+            value, you can ensure fair assessments by discarding outputs 
+            from the specified warmup period (as is done automatically during
+            calibration).
 
         Returns
         -------


### PR DESCRIPTION
Adding a warmup option to eval() to avoid computing the metric on the warmup period of the simulation.