### PR TITLE
Avoids unrealistic snow accumulation.

### DIFF
--- a/core/src/processes/ProcessLateralSnowSlide.h
+++ b/core/src/processes/ProcessLateralSnowSlide.h
@@ -13,6 +13,8 @@
 
 #include "ProcessLateral.h"
 
+class FluxToBrick;
+
 class ProcessLateralSnowSlide : public ProcessLateral {
   public:
     explicit ProcessLateralSnowSlide(WaterContainer* container);
@@ -54,6 +56,17 @@ class ProcessLateralSnowSlide : public ProcessLateral {
      * @copydoc Process::GetRates()
      */
     vecDouble GetRates() override;
+
+  private:
+    /**
+     * Avoid unrealistic accumulation rates by not redistributing snow if the target snowpack has more than twice the
+     * overall maximum snow depth.
+     *
+     * @param rate The rate to check.
+     * @param flux The flux to the target brick.
+     * @return the corrected rate.
+     */
+    double AvoidUnrealisticAccumulation(double rate, Flux* flux);
 };
 
 #endif  // HYDROBRICKS_PROCESS_LATERAL_SNOWSLIDE_H

--- a/python/examples/basics/snow_redistribution.py
+++ b/python/examples/basics/snow_redistribution.py
@@ -63,7 +63,7 @@ for with_snow_redistribution in [True, False]:
             'snow_slide_min_slope': 10,
             'snow_slide_max_slope': 75,
             'snow_slide_min_snow_depth': 50,
-            'snow_slide_max_snow_depth': -1  # Not in original method. -1 = no limit.
+            'snow_slide_max_snow_depth': 20000  # Not in original method. -1 = no limit.
         }
     else:
         params = {


### PR DESCRIPTION
Prevents lateral snow slide from causing unrealistic snow accumulation in target areas by limiting redistribution when the target snowpack already exceeds a threshold.

Updates default maximum snow depth parameter.